### PR TITLE
feat: add compose scripts for posts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,8 @@ group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.12"
   gem "jekyll-paginate"
   gem "jekyll-seo-tag"
+  gem "jekyll-sitemap"
+  gem "jekyll-compose"
   # Lunr.js 검색은 수동으로 구현할 것이므로 플러그인은 사용하지 않음
 end
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# Keto's Blog
+
+이 저장소는 [Jekyll](https://jekyllrb.com/)을 사용한 블로그입니다.
+
+## 개발 환경 설정
+
+```bash
+bundle install
+```
+
+로컬 서버 실행:
+
+```bash
+bundle exec jekyll serve
+```
+
+## 새 글 작성하기
+
+[jekyll-compose](https://github.com/jekyll/jekyll-compose) 플러그인을 사용하여 손쉽게 새 글과 초안을 생성할 수 있습니다.
+
+새 글(post) 생성:
+
+```bash
+bin/new-post "제목"
+```
+
+초안(draft) 생성:
+
+```bash
+bin/new-draft "제목"
+```
+
+생성된 파일을 수정하여 내용을 작성한 후 커밋하면 됩니다.
+

--- a/_config.yml
+++ b/_config.yml
@@ -34,6 +34,7 @@ exclude:
   - Gemfile.lock
   - node_modules/
   - vendor/
+  - bin/
 
 # 기본 레이아웃과 포맷
 defaults:

--- a/bin/new-draft
+++ b/bin/new-draft
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Create a new Jekyll draft with the given title
+set -e
+bundle exec jekyll draft "$@"
+

--- a/bin/new-post
+++ b/bin/new-post
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Create a new Jekyll post with the given title
+set -e
+bundle exec jekyll post "$@"
+


### PR DESCRIPTION
## Summary
- add jekyll-compose and sitemap gems for easier writing
- provide helper scripts to create posts and drafts
- document development workflow and exclude helper scripts from build

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_689a825b149083249b4de2eda72c1296